### PR TITLE
Prep examples for NLL, using drop to model old lexical lifetimes.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 //! let lock = TokenLock::new(&token, 1);
 //! let guard = lock.write(&mut token).unwrap();
 //! drop(lock); // compile error: `guard` cannot outlive `TokenLock`
+//! drop(guard);
 //! ```
 //!
 //! ```compile_fail
@@ -67,6 +68,7 @@
 //! # let lock = TokenLock::new(&token, 1);
 //! # let guard = lock.write(&mut token).unwrap();
 //! drop(token); // compile error: `guard` cannot outlive `Token`
+//! drop(guard);
 //! ```
 //!
 //! It also prevents from forming a reference to the contained value when
@@ -78,6 +80,7 @@
 //! # let lock = TokenLock::new(&token, 1);
 //! let write_guard = lock.write(&mut token).unwrap();
 //! let read_guard = lock.read(&token).unwrap(); // compile error
+//! drop(write_guard);
 //! ```
 //!
 //! While allowing multiple immutable references:


### PR DESCRIPTION
The next version of Rust is going to have NLL enabled on master.

The examples in the current docs assume lexical-scopes for references in order to enforce the properties it claims. So we need to do something to adapt things for NLL.

One way to go about this would be to change the API so that `read` and `write` return some type with a destructor, since destructors continue to be invoked according to lexical scope.

But that's a pretty severe change to the API, and I'm not sure if it would buy the clients of this crate anything.

So this PR takes the other option, of adapting the examples themselves to explicitly drop the guards.

However, I'm honestly not sure what the actual intent is for the API itself. If you really are not expecting clients to include some sort of use of the references being returned from `read`/`write` when they need the current liveness property enforced, then maybe a type with a destructor **would** be the right answer (even though I imagine that would be a big breaking change).