### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ doc_cfg = []
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-spin = { version = "0.9.2", optional = true }
+spin = { version = "0.9.8", optional = true }
 
 [dependencies.const-default_1]
 package = "const-default"


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)